### PR TITLE
Linux (and mac) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
         "start": "electron-forge start",
         "package": "electron-forge package",
         "make": "electron-forge make",
+        "make-mac": "electron-forge make --platform darwin",
+        "make-linux": "electron-forge make --platform linux --target zip",
         "webapp": "node webapp.js",
         "server": "node server/server.js",
         "watch": "webpack --config webpack.common.js --watch",
@@ -77,16 +79,9 @@
                 {
                     "name": "@electron-forge/maker-zip",
                     "platforms": [
-                        "darwin"
+                        "darwin",
+                        "linux"
                     ]
-                },
-                {
-                    "name": "@electron-forge/maker-deb",
-                    "config": {}
-                },
-                {
-                    "name": "@electron-forge/maker-rpm",
-                    "config": {}
                 }
             ]
         }

--- a/src/js/GameRoom.js
+++ b/src/js/GameRoom.js
@@ -8,6 +8,7 @@ import { APP_STATE } from './constants/app_state'
 import back_arrow_icon from "../icons/back_arrow.svg"
 import popout_icon from "../icons/popout.svg"
 import info_icon from "../icons/info.svg"
+import SMInstallation from './SMEnvironment';
 
 // Raw SM import data from txt file
 let sm_data = ""
@@ -83,63 +84,15 @@ export default class GameRoom extends React.Component {
         }, SM_CHECK_INTERVAL_TIME);
 
         const dir = localStorage.getItem("stepmania_dir");
-        if (dir && dir.includes("5.3"))
-        {
-            // StepMania 5.3, so update path
-            const sm_dir_path = dir.replace("Appearance", "")
-            const portable_path = sm_dir_path + "/portable.ini"
 
-            // If they are in portable mode
-            if (electron.fs.existsSync(portable_path))
-            {
-                SM_FILE_PATH = sm_dir_path + "/Save/everyone.dance.txt"
-                NOT_APPDATA = true;
-            }
-            else
-            {
-                SM_FILE_PATH = "/StepMania 5.3/Save/everyone.dance.txt"
-            }
-        }
-        else if (dir && dir.toLowerCase().includes("club") && dir.toLowerCase().includes("fantastic"))
-        {
-            // Check if it is portable mode, aka non appdata
-            const sm_dir_path = dir
-            const portable_path = sm_dir_path + "/portable.ini"
-
-            if (electron.fs.existsSync(portable_path))
-            {
-                SM_FILE_PATH = sm_dir_path + "/Save/everyone.dance.txt"
-                NOT_APPDATA = true;
-            }
-            else
-            {
-                SM_FILE_PATH = "/Club Fantastic StepMania/Save/everyone.dance.txt"
-            }
-
-        }
-        else if (dir)
-        {
-            // Check if it is portable mode, aka non appdata
-            const sm_dir_path = dir
-            const portable_path = sm_dir_path + "/portable.ini"
-
-            if (electron.fs.existsSync(portable_path))
-            {
-                SM_FILE_PATH = sm_dir_path + "/Save/everyone.dance.txt"
-                NOT_APPDATA = true;
-            }
-            else
-            {
-                SM_FILE_PATH = "/StepMania 5/Save/everyone.dance.txt"
-            }
-
-        }
+        const sm_install = new SMInstallation(dir);
+        NOT_APPDATA = sm_install.is_portable;
+        SM_FILE_PATH = sm_install.score_file;
     }
 
     check_for_sm_updates()
     {
-        const file_path = NOT_APPDATA ? SM_FILE_PATH : electron.getAppDataPath() + SM_FILE_PATH;
-
+        const file_path = SM_FILE_PATH;
         if (this.state.full_file_path != file_path)
         {
             this.setState({full_file_path: file_path})

--- a/src/js/SMEnvironment.js
+++ b/src/js/SMEnvironment.js
@@ -1,0 +1,140 @@
+
+/** 
+ * Overall variant of stepmania install
+ * Generally breaks down into Major.Minor version,
+ * or forked variants of these for club fantastic-like installations
+ */
+export const SM_INSTALL_VARIANT = {
+  SM_UNKNOWN: 0,
+  SM_5_0: 1,
+  SM_5_1: 2,
+  // 5.2 was never released, no one should be running it
+  SM_5_3: 3,
+  SM_CLUB_FANTASTIC: 4,
+};
+
+/**
+ * Functionality for determining Stepmania installation type
+ * and locating paths
+ */
+export default class SMInstallation {
+  
+  /**
+   * Construct the class and analyse a sm installation
+   * @param {String} stepmania_dir Path to stepmania installation
+   * @param {String} platform Platform string from electron.process.platform
+   */
+  constructor(stepmania_dir, platform) {
+    // TODO: I wanted to import process from 'electron' in this file,
+    // but when I did that the app wouldn't start, error 'require is not defined'
+    this.platform = electron.os.platform();
+
+    this.install_variant = this._install_variant(stepmania_dir);
+    this.variant_dir = this._locate_variant_install(stepmania_dir);
+    this.is_portable = this._is_portable(this.variant_dir);
+    this.score_file = this._locate_score_file(this.variant_dir);
+  }
+
+  /**
+   * Determine the overall variant of stepmania
+   * @param {String} stepmania_dir Path to stepmania installation
+   * @returns {SM_INSTALL_VARIANT} The installation variant
+   */
+  _install_variant(stepmania_dir) {
+    if( !stepmania_dir ) return SM_UNKNOWN;
+
+    if( stepmania_dir.toLowerCase().includes("club") && stepmania_dir.toLowerCase().includes("fantastic") )
+    {
+      return SM_INSTALL_VARIANT.SM_CLUB_FANTASTIC;
+    }
+    else if( stepmania_dir.includes("5.0") )
+    {
+      return SM_INSTALL_VARIANT.SM_5_0;
+    }
+    else if( stepmania_dir.includes("5.1") )
+    {
+      return SM_INSTALL_VARIANT.SM_5_1;
+    }
+    else if( stepmania_dir.includes("5.3") )
+    {
+      return SM_INSTALL_VARIANT.SM_5_3;
+    }
+    return SM_INSTALL_VARIANT.SM_UNKNOWN;
+  }
+
+  /**
+   * Given a base install directory, apply per-variant
+   * suffixes as required
+   * @param {String} stepmania_dir Path to stepmania installation
+   * @returns {String} Updated directory to account for install variant
+   */
+  _locate_variant_install(stepmania_dir) {
+    if( this.install_variant && this.install_variant === SM_INSTALL_VARIANT.SM_5_3 ) {
+      return stepmania_dir.replace("Appearance", "");
+    }
+    return stepmania_dir;
+  }
+
+  /**
+   * Check if a stepmania install is in portable mode
+   * Portable installs store everything next to the
+   * sm executable, and don't store information in 
+   * per user/appdata folders
+   */
+  _is_portable() {
+    const portable_path = this.variant_dir + "/portable.ini";
+    return electron.fs.existsSync(portable_path);
+  }
+
+  /**
+   * Locate everyone.dance.txt within the sm
+   * installation, or appdata directories
+   * @returns {String} Path to everyone.dance.txt
+   */
+  _locate_score_file() {
+    // Portable installs are simple - Save folder is next to executable
+    if( this.is_portable )
+    {
+      return this.variant_dir + "/Save/everyone.dance.txt";
+    }
+
+    // For standard installs it's more complicated - Save folder is in user data
+    // Windows: AppData/Stepmania X.Y
+    if( this.platform === "win32" )
+    {
+      if( this.install_variant === SM_INSTALL_VARIANT.SM_5_0 ||
+          this.install_variant === SM_INSTALL_VARIANT.SM_5_1 )
+      {
+        return electron.getAppDataPath() + "/StepMania 5/Save/everyone.dance.txt";
+      }
+      else if( this.install_variant === SM_INSTALL_VARIANT.SM_5_3 )
+      {
+        return electron.getAppDataPath() + "/StepMania 5.3/Save/everyone.dance.txt";
+      }
+      else if( this.install_variant === SM_INSTALL_VARIANT.SM_CLUB_FANTASTIC )
+      {
+        return electron.getAppDataPath() + "/Club Fantastic StepMania/Save/everyone.dance.txt";
+      }
+    }
+    // Linux: ~/.stepmania-X.Y
+    // Mac: Assumed to be same as Linux here
+    else if( this.platform === "linux" || process.platform === "darwin")
+    {
+      if( this.install_variant === SM_INSTALL_VARIANT.SM_5_0 )
+      {
+        return electron.getHomePath() + "/.stepmania-5.0/Save/everyone.dance.txt";
+      }
+      else if( this.install_variant === SM_INSTALL_VARIANT.SM_5_1 )
+      {
+        return electron.getHomePath() + "/.stepmania-5.1/Save/everyone.dance.txt";
+      }
+      else if( this.install_variant === SM_INSTALL_VARIANT.SM_5_3 )
+      {
+        return electron.getHomePath() + "/.stepmania-5.3/Save/everyone.dance.txt";
+      }
+    }
+
+    return null;
+  }
+
+}

--- a/src/js/preload.js
+++ b/src/js/preload.js
@@ -1,4 +1,5 @@
 const electron = require('electron');
+const os = require('os');
 
 electron.contextBridge.exposeInMainWorld('electron', {
     closeWindow() {
@@ -11,11 +12,16 @@ electron.contextBridge.exposeInMainWorld('electron', {
         electron.ipcRenderer.send(event, ...args);
     },
     fs: electron.remote.require('fs'),
+    os: os,
     dirname: __dirname,
     dialog: electron.remote.dialog,
     clipboard: electron.remote.clipboard,
     getAppDataPath()
     {
         return (electron.app || electron.remote.app).getPath('appData')
+    },
+    getHomePath()
+    {
+        return (electron.app || electron.remote.app).getPath('home')
     }
 })


### PR DESCRIPTION
Opening the PR early for feedback/discussion area

Disclaimer: I'm a C++ engineer by trade, will likely make javascript faux-pas

Linux status:
* Target added to package for Linux
* At the moment just packages as zip, could build .deb or .rpm packages for installation to system
* Tried to get AppImage support working, builder didn't seem to work
* When packaged as zip everyone.dance can be run, seems to work as expected
* But due to electron packaging switching to PIE format binaries needed to run from terminal - file manager doesn't recognise the everyone.dance binary on double-click
* UI launches, detects themes/can be installed
* Gameplay/score updates working, at least in stepmania-5.1, non-portable installation

Mac status:
* Target added to package for Mac, packaging as zip (I think an osx app package would be fine, but there's security/signing to worry about these days perhaps?)
* I assume it works - Things seem to work on Linux so far, so it should at least launch

My dev system is Linux Mint 20.x, I assume the linux/mac packages can be built on windows as well?

On a side note - Are releases currently being build by hand, and would you like github actions setup for the repo?