### PR TITLE
[WIP] Optimize SongData file writes by keeping file handle open

### DIFF
--- a/src/js/GameRoom.js
+++ b/src/js/GameRoom.js
@@ -432,8 +432,11 @@ export default class GameRoom extends React.Component {
         {
             const line = lines[i].trim();
 
-            // Empty line
-            if (line.length == 0) {continue;}
+            // Empty line - This indicates the end of the written file.
+            // Because this file is written without closing the file, it may
+            // contain overflow data that was written in previous iterations.
+            // We signal the end of the most recent write with a blank line.
+            if (line.length == 0) {break;}
 
             if (line.includes("PlayerNumber"))
             {

--- a/src/lua/everyone.dance.lua
+++ b/src/lua/everyone.dance.lua
@@ -1,4 +1,5 @@
 local f = RageFileUtil.CreateRageFile()
+local data_file = nil
 local function ReadFile(filename)
     local contents
     if f:Open(filename, 1) then
@@ -11,6 +12,20 @@ local function WriteFile(text, filename)
     if f:Open(filename, 2) then
         f:Write(text)
     end
+end
+
+-- For files that are written during performance-critical times
+-- like song data. Returns a file handle that can be reused by
+-- rewinding to the first byte.
+local function OpenFileForRepeatedWriting(filename)
+  local file = RageFileUtil.CreateRageFile()
+  file:Open(filename, 2)
+  return file
+end
+
+local function RewindAndWriteToFile(file, data)
+  file:Rewind(0)
+  file:Write(data)
 end
 
 -- counts an associative Lua table (use #table for sequential tables)
@@ -259,11 +274,15 @@ local function RefreshActiveSongData()
                 data = data .. key .. ":" .. tostring(value) .. "\n"
             end
         end
+
+        -- Add some closing empty lines since writing the file by rewinding/overwriting might
+        -- leave some garbage data at the end of the file. This gives the parser something
+        -- to search for and consider the end of the relevant data.
+        data = data .. "\n\n"
         
     end
 
-    WriteFile(data, data_filename)
-
+    RewindAndWriteToFile(data_file, data)
 end
 
 local running_time = 0
@@ -338,15 +357,15 @@ local function OnCurrentStepsChanged(s)
 end
 
 local function OnInit(s)
-
     print("Init everyone.dance")
 
     -- Clear file so we don't crash
     WriteFile("", goto_filename)
-    
+
+    data_file = OpenFileForRepeatedWriting(data_filename)
+
     s:sleep(SYNC_INTERVAL / 1000):queuecommand("Update")
     s:sleep(timing_data_interval / 1000):queuecommand("Update2")
-
 end
 
 return Def.ActorFrame{

--- a/src/lua/everyone.dance.lua
+++ b/src/lua/everyone.dance.lua
@@ -1,5 +1,5 @@
 local f = RageFileUtil.CreateRageFile()
-local data_file = nil
+
 local function ReadFile(filename)
     local contents
     if f:Open(filename, 1) then
@@ -19,12 +19,15 @@ end
 -- rewinding to the first byte.
 local function OpenFileForRepeatedWriting(filename)
   local file = RageFileUtil.CreateRageFile()
-  file:Open(filename, 2)
-  return file
+  if file:Open(filename, 2) then
+    return file
+  else
+    error("Unable to open file " .. filename .. " for writing")
+  end
 end
 
 local function RewindAndWriteToFile(file, data)
-  file:Rewind(0)
+  file:Seek(0)
   file:Write(data)
 end
 
@@ -65,6 +68,8 @@ local data_filename = "Save/everyone.dance.txt"
 local data_timings_filename = "Save/everyone.dance.timings.txt"
 local data_game_code_filename = "Save/everyone.dance.gamecode.txt"
 local goto_filename = "Save/everyone.dance.txt.goto"
+
+local data_file = OpenFileForRepeatedWriting(data_filename)
 
 -- Originally from STARLIGHT theme
 function FullComboType(pss)
@@ -359,10 +364,10 @@ end
 local function OnInit(s)
     print("Init everyone.dance")
 
+    -- OpenFileForRepeatedWriting(data_filename)
+
     -- Clear file so we don't crash
     WriteFile("", goto_filename)
-
-    data_file = OpenFileForRepeatedWriting(data_filename)
 
     s:sleep(SYNC_INTERVAL / 1000):queuecommand("Update")
     s:sleep(timing_data_interval / 1000):queuecommand("Update2")


### PR DESCRIPTION
**This is a WIP that needs fixing before it can be safely merged.**

The goal of this PR is to reduce time spent opening/closing file handles during gameplay by reusing the same open filehandle when updating the song data file. It contains the following changes:
- Update everyone.dance.lua to keep a persistent file handle open for the song data file. 
- Update writing song data to seek to the beginning of the file first before writing, and write extra newlines at the end of the file.
- Update the electron client to stop parsing the song data file after the first blank line encountered to prevent accidentally reading partially-overwritten data from previous writes.

WIP:
- [ ] Getting failures when I get to the song wheel in SM5/SL5.0.1 that the file isn't properly opened. I assume I'm getting the control flow a bit incorrect.
- [ ] Haven't set up testing with the electron client yet, not sure if there are any gotchas on the client side.

Current lua failure on load:
```
00:17.101: WARNING: Error playing command:/Themes/Simply Love (For E.D Testing)/BGAnimations/everyone.dance.lua:31: File '/Users/bkirz/Library/Prefer
ences/StepMania 5.1/everyone.dance.txt' is not open for reading.          
00:17.101: WARNING: [C]: Seek( = (null))
```